### PR TITLE
Add gcc for building cftime

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -1,7 +1,7 @@
 FROM jupyter/base-notebook
 
 USER root
-RUN apt update && apt install -y netcdf-bin nco
+RUN apt update && apt install -y netcdf-bin nco gcc
 
 RUN pip3 install -U pip setuptools
 RUN pip3 install scipy pandas matplotlib xarray dask[dataframe] netCDF4 nc-time-axis


### PR DESCRIPTION
Fixes issue with installing cftime in case there is no available binary for a given architecture #104 